### PR TITLE
use HTTPS www.ipify.org urls in comments and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 python-ipify
 ============
 
-The official client library for `ipify <http://www.ipify.org/>`_: *A Simple IP
+The official client library for `ipify <https://www.ipify.org/>`_: *A Simple IP
 Address API*.
 
 .. image:: https://img.shields.io/pypi/v/ipify.svg
@@ -32,7 +32,7 @@ Meta
 Purpose
 -------
 
-`ipify <http://www.ipify.org/>`_ is the best IP address lookup service on the
+`ipify <https://www.ipify.org/>`_ is the best IP address lookup service on the
 internet.  It's fast, simple, scalable, open source, and well-funded (*by me!*).
 
 In short: if you need a way to pragmatically get your public IP address, ipify

--- a/ipify/__init__.py
+++ b/ipify/__init__.py
@@ -2,7 +2,7 @@
 ipify
 ~~~~~
 
-The official client library for ipify: http://www.ipify.org - A Simple IP
+The official client library for ipify: https://www.ipify.org - A Simple IP
 Address API.
 
 ipify will get your public IP address, and return it.  No questions asked.
@@ -17,7 +17,7 @@ ipify is a great choice because it's:
     - Personally funded by Randall Degges (http://www.rdegges.com), so it
       won't just *disappear* some day.
 
-For more information, visit the project website: http://www.ipify.org
+For more information, visit the project website: https://www.ipify.org
 
 -Randall
 """

--- a/ipify/ipify.py
+++ b/ipify/ipify.py
@@ -18,7 +18,7 @@ from .settings import API_URI, MAX_TRIES, USER_AGENT
 def _get_ip_resp():
     """
     Internal function which attempts to retrieve this machine's public IP
-    address from the ipify service (http://www.ipify.org).
+    address from the ipify service (https://www.ipify.org).
 
     :rtype: obj
     :returns: The response object from the HTTP request.
@@ -35,7 +35,7 @@ def _get_ip_resp():
 
 def get_ip():
     """
-    Query the ipify service (http://www.ipify.org) to retrieve this machine's
+    Query the ipify service (https://www.ipify.org) to retrieve this machine's
     public IP address.
 
     :rtype: string


### PR DESCRIPTION
Use the TLS-secured URLs when linking to www.ipify.org.

We were already doing this for the api.ipify.org endpoint; might as well do it for www also.
