### PR TITLE
test_return_ip_address actually validates ip

### DIFF
--- a/tests/test_ipify.py
+++ b/tests/test_ipify.py
@@ -55,4 +55,23 @@ class GetIpTest(BaseTest):
         self.assertRaises(ServiceError, get_ip)
 
     def test_returns_ip_address(self):
-        self.assertTrue(get_ip())
+        from ipify import get_ip
+        import socket
+
+        def valid_ip(ip):
+            try:
+                #IPv4
+                socket.inet_pton(socket.AF_INET, ip)
+                return True
+            except OSError:
+                pass
+            try:
+                #IPv6
+                socket.inet_pton(socket.AF_INET6, ip)
+                return True
+            except OSError:
+                pass
+            
+            return False
+
+        self.assertTrue(valid_ip(get_ip()))


### PR DESCRIPTION
Before, it was just validating the truthiness of the IP returned by the API. If it returned a filled dict or list, that test would pass. This creates IP4 and IP6 sockets to test for an IP properly.
