### PR TITLE
import linux_distribution from distro

### DIFF
--- a/ipify/settings.py
+++ b/ipify/settings.py
@@ -6,7 +6,8 @@ This module contains internal settings that make our ipify library simpler.
 """
 
 
-from platform import mac_ver, win32_ver, linux_distribution, system
+from platform import mac_ver, win32_ver, system
+from distro import linux_distribution
 from sys import version_info as vi
 
 from . import __version__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest>=2.7.0
 pytest-cov>=1.8.1
 python-coveralls>=2.5.0
+distro>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 
     # Basic package information:
     name = 'ipify',
-    version = '1.0.0',
+    version = '1.0.1',
     packages = find_packages(exclude=['tests']),
 
     # Packaging options:


### PR DESCRIPTION
As it turns out, python3.8+ no longer ships with the `linux_distribution` function in the `platform` module (see https://bugs.python.org/issue28167). The docs recommend instead to use the homonym function from the [`distro` package](https://pypi.org/project/distro/). This pull request

1. installs the `distro` package
1. imports `linux_distribution` from `distro`
1. upgrades the package version to 1.0.1