### PR TITLE
replace linux_distribution function

### DIFF
--- a/ipify/settings.py
+++ b/ipify/settings.py
@@ -6,7 +6,7 @@ This module contains internal settings that make our ipify library simpler.
 """
 
 
-from platform import mac_ver, win32_ver, linux_distribution, system
+from platform import mac_ver, win32_ver, release, system
 from sys import version_info as vi
 
 from . import __version__
@@ -21,7 +21,7 @@ MAX_TRIES = 3
 # This dictionary is used to dynamically select the appropriate platform for
 # the user agent string.
 OS_VERSION_INFO = {
-    'Linux': '%s' % (linux_distribution()[0]),
+    'Linux': '%s' % (release()),
     'Windows': '%s' % (win32_ver()[0]),
     'Darwin': '%s' % (mac_ver()[0]),
 }

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 
     # Basic package information:
     name = 'ipify',
-    version = '1.0.0',
+    version = '1.0.1',
     packages = find_packages(exclude=['tests']),
 
     # Packaging options:


### PR DESCRIPTION
linux_distribution() has been removed from the platform library. This pull request uses platform.release() for the user agent string for linux clients.

#7 is also a viable alternative, but requiring a 3rd party package seems overkill just to generate a user agent string but using the release() will not be consistent with historical data, @rdegges decision if that is significant.