### PR TITLE
Updated to use Distro package for Python 3.8 compatibility

### DIFF
--- a/ipify/settings.py
+++ b/ipify/settings.py
@@ -6,7 +6,8 @@ This module contains internal settings that make our ipify library simpler.
 """
 
 
-from platform import mac_ver, win32_ver, linux_distribution, system
+from platform import mac_ver, win32_ver, system
+from distro import linux_distribution
 from sys import version_info as vi
 
 from . import __version__

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     install_requires = [
         'backoff>=1.0.7',
         'requests>=2.7.0',
+        'distro>=1.4.0',
     ],
     tests_require = [
         'pytest>=2.7.0',


### PR DESCRIPTION
platform.linux_distribution was removed in Python 3.8 and Distro is the recommended replacement.

I'm still pretty new to this so I can't figure out why when I run `python setup.py test` I get this error:
```
running test
error: [WinError 2] The system cannot find the file specified
```
If I run the tests manually with `py.test --cov-report term-missing --cov ipify`, it gets 100% coverage but test_ipify.py reports 71%.