### PR TITLE
linux_distribution in platform is deprecated in Python 3.5 and removed in Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.egg-info
 build
 dist
+
+# JetBrains/PyCharm
+.idea/
+venv*/

--- a/ipify/settings.py
+++ b/ipify/settings.py
@@ -6,7 +6,7 @@ This module contains internal settings that make our ipify library simpler.
 """
 
 
-from platform import mac_ver, win32_ver, linux_distribution, system
+from platform import mac_ver, win32_ver, system, platform
 from sys import version_info as vi
 
 from . import __version__
@@ -21,7 +21,7 @@ MAX_TRIES = 3
 # This dictionary is used to dynamically select the appropriate platform for
 # the user agent string.
 OS_VERSION_INFO = {
-    'Linux': '%s' % (linux_distribution()[0]),
+    'Linux': '%s' % (platform()),
     'Windows': '%s' % (win32_ver()[0]),
     'Darwin': '%s' % (mac_ver()[0]),
 }


### PR DESCRIPTION
linux_distribution in platform is deprecated in Python 3.5 and removed in Python 3.8

Remove linux_distribution import. Replace the call to linux_distribution for Linux systems with the human readable output of platform().

Example Linux USER_AGENT: `python-ipify/1.0.0 python/3.8.3 Linux/Linux-5.6.16-1-MANJARO-x86_64-with-glibc2.2.5` or `python-ipify/1.0.0 python/2.7.18 Linux/Linux-5.6.16-1-MANJARO-x86_64-with-glibc2.2.5`

Update .gitignore to exclude JetBrains workspace junk.

Tested on Manjaro with Python 3.8 and Python 2.7